### PR TITLE
GitHub-inspired redesign for Mezkenz site

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { getDictionary } from "@/lib/dictionaries";
 import { defaultLocale, isLocale, type Locale } from "@/lib/i18n";
 import "@/styles/globals.css";
-const inter = Inter({ subsets: ["latin"] });
 export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
   const locale = isLocale(params.locale) ? (params.locale as Locale) : defaultLocale;
   const dict = await getDictionary(locale);
@@ -11,5 +9,9 @@ export async function generateMetadata({ params }: { params: { locale: string } 
 }
 export default async function RootLayout({ children, params }: { children: React.ReactNode; params: { locale: string } }) {
   const locale = isLocale(params.locale) ? (params.locale as Locale) : defaultLocale;
-  return (<html lang={locale}><body className={inter.className}>{children}</body></html>);
+  return (
+    <html lang={locale}>
+      <body className="antialiased">{children}</body>
+    </html>
+  );
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,74 +1,119 @@
 import Link from "next/link";
-import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowRight, Mail, Linkedin, CheckCircle2 } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { getDictionary } from "@/lib/dictionaries";
 import { isLocale, type Locale, defaultLocale } from "@/lib/i18n";
 
-// ✅ Server Component
 export default async function Page({ params }: { params: { locale: string } }) {
   const loc = isLocale(params.locale) ? (params.locale as Locale) : defaultLocale;
   const dict = await getDictionary(loc);
 
   return (
-    <div className="min-h-screen bg-[rgb(11,12,16)] text-zinc-100">
-      <header className="sticky top-0 z-50 border-b border-white/5 bg-[rgba(11,12,16,0.65)] backdrop-blur-md">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-3">
+    <div className="min-h-screen bg-white text-gray-900">
+      <header className="bg-[#24292f] text-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
           <Link href={`/${loc}`} className="flex items-center gap-3">
-            <img src="/MEZKENZ_logo_gray.jpg" alt="Mezkenz logo" className="h-10 w-10 object-contain grayscale" />
+            <img src="/MEZKENZ_logo_gray.jpg" alt="Mezkenz logo" className="h-8 w-8 object-contain" />
             <strong className="tracking-wider">MEZKENZ</strong>
           </Link>
-          <nav className="hidden gap-2 md:flex">
-            <Link className="rounded-xl px-3 py-2 text-zinc-300 hover:bg-white/5" href={`/${loc}#diensten`}>{dict.nav.services}</Link>
-            <Link className="rounded-xl px-3 py-2 text-zinc-300 hover:bg-white/5" href={`/${loc}#over`}>{dict.nav.about}</Link>
-            <Link className="rounded-xl px-3 py-2 text-zinc-300 hover:bg-white/5" href={`/${loc}#contact`}>{dict.nav.contact}</Link>
+          <nav className="hidden gap-6 md:flex">
+            <Link className="hover:text-gray-300" href={`/${loc}#diensten`}>{dict.nav.services}</Link>
+            <Link className="hover:text-gray-300" href={`/${loc}#over`}>{dict.nav.about}</Link>
+            <Link className="hover:text-gray-300" href={`/${loc}#contact`}>{dict.nav.contact}</Link>
           </nav>
           <div className="flex items-center gap-3">
             <LanguageSwitcher locale={loc} />
-            <Button asChild className="bg-gradient-to-tr from-sky-500 to-sky-300 text-slate-900 font-bold">
+            <Button asChild>
               <Link href={`/${loc}#contact`}>{dict.nav.cta}</Link>
             </Button>
           </div>
         </div>
       </header>
 
-      <section className="mx-auto max-w-6xl px-4 pb-10 pt-16 md:pt-24">
-        <div className="grid items-center gap-8 md:grid-cols-2">
-          <motion.div initial={{ opacity: 0, y: 12 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.6 }}>
-            <span className="inline-block rounded-full border border-white/10 px-3 py-1 text-sm text-zinc-300">{dict.hero.tag}</span>
-            <h1 className="mt-3 text-4xl leading-tight md:text-5xl">{dict.hero.title}</h1>
-            <p className="mt-3 max-w-xl text-lg text-zinc-300" dangerouslySetInnerHTML={{ __html: dict.hero.lead }} />
-            <div className="mt-5 flex flex-wrap gap-3">
-              <Button asChild className="bg-gradient-to-tr from-sky-500 to-sky-300 text-slate-900 font-bold">
-                <Link href={`/${loc}#contact`} className="flex items-center gap-2">{dict.hero.ctaPrimary} <ArrowRight className="h-4 w-4" /></Link>
-              </Button>
-              <Button asChild variant="outline" className="border-white/15 bg-white/5">
-                <Link href={`/${loc}#diensten`}>{dict.hero.ctaSecondary}</Link>
-              </Button>
-            </div>
-          </motion.div>
+      <section className="mx-auto max-w-6xl px-4 py-16">
+        <span className="inline-block rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700">{dict.hero.tag}</span>
+        <h1 className="mt-4 text-4xl font-bold md:text-5xl">{dict.hero.title}</h1>
+        <p className="mt-4 max-w-2xl text-lg" dangerouslySetInnerHTML={{ __html: dict.hero.lead }} />
+        <div className="mt-6 flex flex-wrap gap-4">
+          <Button asChild>
+            <Link href={`/${loc}#contact`}>{dict.hero.ctaPrimary}</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/${loc}#diensten`}>{dict.hero.ctaSecondary}</Link>
+          </Button>
+        </div>
+        <ul className="mt-10 space-y-2">
+          {dict.hero.whyPoints.map((t: string, i: number) => (
+            <li key={i} className="flex items-start gap-2">
+              <CheckCircle2 className="mt-1 h-5 w-5 text-[#2ea44f]" />
+              <span dangerouslySetInnerHTML={{ __html: t }} />
+            </li>
+          ))}
+        </ul>
+      </section>
 
-          <motion.div initial={{ opacity: 0, y: 12 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.6, delay: 0.1 }}>
-            <Card>
-              <CardHeader><CardTitle>{dict.hero.why}</CardTitle></CardHeader>
+      <section id="diensten" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-3xl font-bold">{dict.services.title}</h2>
+        <p className="mt-2 text-lg">{dict.services.subtitle}</p>
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {dict.services.items.map((item: any, i: number) => (
+            <Card key={i} className="border border-gray-200">
+              <CardHeader>
+                <CardTitle>{item.title}</CardTitle>
+              </CardHeader>
               <CardContent>
-                <ul className="space-y-3 text-zinc-300">
-                  {dict.hero.whyPoints.map((t: string, i: number) => (
-                    <li key={i} className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-5 w-5 text-sky-400" /> <span dangerouslySetInnerHTML={{ __html: t }} /></li>
+                <ul className="list-disc space-y-1 pl-5">
+                  {item.bullets.map((b: string, j: number) => (
+                    <li key={j}>{b}</li>
                   ))}
                 </ul>
               </CardContent>
             </Card>
-          </motion.div>
+          ))}
         </div>
       </section>
 
-      {/* Services / About / Contact secties: identiek aan je vorige versie, maar met dict-teksten */}
+      <section id="over" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-3xl font-bold">{dict.about.title}</h2>
+        <p className="mt-4" dangerouslySetInnerHTML={{ __html: dict.about.text1 }} />
+        <p className="mt-4 font-semibold">{dict.about.mission}</p>
+        <h3 className="mt-6 text-xl font-semibold">{dict.about.strengthsTitle}</h3>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          {dict.about.strengths.map((s: string, i: number) => (
+            <li key={i} dangerouslySetInnerHTML={{ __html: s }} />
+          ))}
+        </ul>
+      </section>
+
+      <section id="contact" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-3xl font-bold">{dict.contact.title}</h2>
+        <p className="mt-2 text-lg">{dict.contact.subtitle}</p>
+        <form className="mt-6 grid gap-4 md:grid-cols-2">
+          <Input placeholder={dict.contact.form.name} />
+          <Input placeholder={dict.contact.form.company} />
+          <Input placeholder={dict.contact.form.email} className="md:col-span-2" />
+          <Textarea placeholder={dict.contact.form.message} className="md:col-span-2" />
+          <Button className="md:col-span-2">{dict.contact.form.send}</Button>
+        </form>
+        <p className="mt-6">
+          {dict.contact.form.orMail}: <a href="mailto:info@mezkenz.com" className="text-[#0969da]">info@mezkenz.com</a>
+        </p>
+        <div className="mt-6">
+          <h3 className="font-semibold">{dict.contact.business.heading}</h3>
+          <p className="text-sm text-gray-600">{dict.contact.business.kbo}</p>
+        </div>
+      </section>
+
+      <footer className="border-t bg-gray-100 py-6">
+        <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-4 text-sm text-gray-600 md:flex-row md:justify-between">
+          <p>{dict.footer.made}</p>
+          <p>{dict.footer.rights}</p>
+        </div>
+      </footer>
     </div>
   );
 }
-

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,16 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "@/styles/globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
-
 export const metadata: Metadata = {
-  title: "Mezkenz – IT TeamLead Services & Coaching",
-  description: "Mezkenz helpt bedrijven met IT teamleiderschap, coaching, teamopbouw, outsourcing en projectassistentie.",
+  title: "Mezkenz – IT Leadership & Consultancy",
+  description:
+    "Independent IT Support Leader offering team lead services, project management, process improvement and IT consultancy.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="nl">
-      <body className={inter.className}>{children}</body>
+    <html lang="en">
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,12 +4,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-2xl text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 disabled:pointer-events-none disabled:opacity-50 px-4 py-2",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2ea44f] disabled:pointer-events-none disabled:opacity-50 px-4 py-2",
   {
     variants: {
       variant: {
-        default: "bg-gradient-to-tr from-sky-500 to-sky-300 text-slate-900",
-        outline: "border border-white/15 bg-white/5 text-zinc-100",
+        default: "bg-[#2ea44f] hover:bg-[#2c974b] text-white",
+        outline: "border border-gray-300 bg-white hover:bg-gray-100 text-gray-900",
       }
     },
     defaultVariants: { variant: "default" }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("rounded-2xl border border-white/10 bg-white/[0.04] shadow-sm", className)} {...props} />;
+  return <div className={cn("rounded-md border border-gray-200 bg-white shadow-sm", className)} {...props} />;
 }
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("p-5", className)} {...props} />;

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -5,7 +5,10 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => (
     <input
-      className={cn("flex h-11 w-full rounded-xl border border-white/15 bg-zinc-900/80 px-3 text-sm text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-sky-400", className)}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2ea44f]",
+        className
+      )}
       ref={ref}
       {...props}
     />

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -5,7 +5,10 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => (
     <textarea
-      className={cn("min-h-[120px] w-full rounded-xl border border-white/15 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-sky-400", className)}
+      className={cn(
+        "min-h-[120px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2ea44f]",
+        className
+      )}
       ref={ref}
       {...props}
     />

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,21 +1,74 @@
 {
-  "meta": { "title": "Mezkenz – IT TeamLead Services & Coaching", "description": "Mezkenz helps companies build, lead and optimize IT teams: coaching, team building, outsourcing and delivery support." },
-  "nav": { "services": "Services", "about": "About", "contact": "Contact", "cta": "Book a call" },
-  "hero": { "tag": "IT Team Leadership • Coaching • Team Building", "title": "Your partner in IT team leadership and growth",
-    "lead": "I help companies build, lead and optimize IT teams. From coaching internal team leads to outsourcing complete teams — Mezkenz brings structure, speed and results. We help bring tools to production with a focus on productivity and team motivation.",
-    "ctaPrimary": "Book a call", "ctaSecondary": "See services", "why": "Why Mezkenz?",
-    "whyPoints": ["Build teams from scratch, clarify roles and streamline hiring.","Leadership & coaching that boost motivation and ownership.","Better predictability: clear cadence, metrics and delivery.","Available in 🇧🇪 and remote internationally."] },
-  "services": { "title": "Services", "subtitle": "Choose the support that moves you forward today.",
+  "meta": { "title": "Mezkenz – IT Leadership & Consultancy", "description": "Independent IT Support Leader offering team lead services, project management, process improvement and IT consultancy." },
+  "nav": { "services": "Services", "about": "About", "contact": "Contact", "cta": "Get in touch" },
+  "hero": {
+    "tag": "Independent IT Support Leader",
+    "title": "25+ Years Driving Service Excellence",
+    "lead": "Starting October 2025 I will operate as an independent professional helping organizations elevate service desk and end-user support operations.",
+    "ctaPrimary": "Get in touch",
+    "ctaSecondary": "View services",
+    "why": "What I Offer",
+    "whyPoints": [
+      "Interim IT support team leadership & supervision.",
+      "Process optimization and ITIL\u00a04–driven service improvements.",
+      "Microsoft\u00a0365 & ServiceNow implementation and management.",
+      "Mentoring and developing high-performing support teams."
+    ]
+  },
+  "services": {
+    "title": "Services",
+    "subtitle": "Support to stabilize, optimize or transform your IT operations.",
     "items": [
-      { "title": "IT TeamLead Services", "bullets": ["Interim or external team lead bringing structure and pace.","Roadmaps, cadence (scrum) and clear responsibilities.","Focus on productivity and team motivation."] },
-      { "title": "IT Coaching", "bullets": ["1‑on‑1 guidance for (new) team leads.","Communication, feedback and stakeholder management.","Team performance and growth."] },
-      { "title": "Team Building & Outsourcing", "bullets": ["Advice and execution for assembling teams.","Outsourcing strategy, partner selection and governance.","Knowledge transfer and onboarding."] },
-      { "title": "Project Assistance", "bullets": ["Implementation and go‑live support for new tools.","Process improvement and documentation.","Temporary reinforcement for teams."] }
-    ]},
-  "about": { "title": "About Mezkenz", "text1": "I'm <b>[your name]</b>, an IT Team Lead with experience building and leading teams. I combine technical know‑how with leadership and coaching so organizations not only ship projects but also build strong teams ready for the future.", "mission": "Mission: sustainable IT teams that work efficiently, stay motivated and think ahead.", "strengthsTitle": "Strengths",
-    "strengths": ["Teams from scratch: roles, hiring, onboarding","Clear metrics and cadence; better predictability","Coaching approach that motivates and drives ownership"] },
-  "contact": { "title": "Contact", "subtitle": "Ready to spar? Send a message or book a call.",
+      {
+        "title": "IT Team Lead Services",
+        "bullets": [
+          "Hands-on leadership for service desks and support teams.",
+          "Coaching and performance follow-up to build accountable teams.",
+          "Coordination across regions and vendors."
+        ]
+      },
+      {
+        "title": "Project Management",
+        "bullets": [
+          "Service transitions and IT migrations.",
+          "Rollout of new tools and services.",
+          "KPI tracking and reporting."
+        ]
+      },
+      {
+        "title": "Process Improvement",
+        "bullets": [
+          "ITIL\u00a04 based process optimization.",
+          "Knowledge management and documentation.",
+          "Reducing downtime and increasing user satisfaction."
+        ]
+      },
+      {
+        "title": "IT Consultancy",
+        "bullets": [
+          "Microsoft\u00a0365 & ServiceNow implementation.",
+          "Mentoring for team leads and support staff.",
+          "Strategy to build high-performing support operations."
+        ]
+      }
+    ]
+  },
+  "about": {
+    "title": "About Mezkenz",
+    "text1": "I'm <b>Mezkenz</b>, an IT support leader with more than 25 years of experience including 9 years as team lead and supervisor. I combine technical expertise with people-focused leadership to deliver stable, efficient and motivated support teams.",
+    "mission": "Mission: provide proven leadership that keeps your IT support running and evolving.",
+    "strengthsTitle": "Experience Highlights",
+    "strengths": [
+      "FedEx IT Support Supervisor 2018–2025, coordinating L2 support across Europe.",
+      "Led service transitions for multinational mergers and migrations.",
+      "ITIL\u00a04 Certified; extensive Microsoft 365 and ServiceNow expertise."
+    ]
+  },
+  "contact": {
+    "title": "Contact",
+    "subtitle": "Let's connect if you need leadership to stabilize or transform your IT support.",
     "form": { "name": "Name", "company": "Company", "email": "Email", "message": "Message", "send": "Send", "orMail": "Or email directly" },
-    "business": { "heading": "Company details", "kbo": "KBO: [after registration] · VAT: [after activation]" } },
-  "footer": { "made": "Made with ❤️ for high‑performing teams", "rights": "All rights reserved" }
+    "business": { "heading": "Company details", "kbo": "KBO: [after registration] · VAT: [after activation]" }
+  },
+  "footer": { "made": "Made with ❤️ for service excellence", "rights": "All rights reserved" }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,21 +1,74 @@
 {
-  "meta": { "title": "Mezkenz – IT TeamLead Services & Coaching", "description": "Mezkenz helpt bedrijven met IT teamleiderschap, coaching, teamopbouw, outsourcing en delivery support." },
-  "nav": { "services": "Diensten", "about": "Over", "contact": "Contact", "cta": "Plan een kennismaking" },
-  "hero": { "tag": "IT Teamleiderschap • Coaching • Teamopbouw", "title": "Jouw partner in IT teamleiderschap en groei",
-    "lead": "Ik help bedrijven bij het bouwen, leiden en optimaliseren van IT‑teams. Van coaching van interne teamleads tot het outsourcen van complete teams — Mezkenz brengt structuur, snelheid en resultaat. We helpen tools succesvol in productie te brengen met focus op productiviteit én teammotivatie.",
-    "ctaPrimary": "Plan een kennismaking", "ctaSecondary": "Bekijk diensten", "why": "Waarom Mezkenz?",
-    "whyPoints": ["Teams vanaf nul opbouwen, rollen scherp zetten en hiring stroomlijnen.","Leiderschap & coaching die motivatie en eigenaarschap versterken.","Betere voorspelbaarheid: duidelijke ritmes, metrics en delivery.","Beschikbaar in 🇧🇪 en remote internationaal."] },
-  "services": { "title": "Diensten", "subtitle": "Kies de ondersteuning die je vandaag sneller vooruit helpt.",
+  "meta": { "title": "Mezkenz – IT Leadership & Consultancy", "description": "Independent IT Support Leader offering team lead services, project management, process improvement and IT consultancy." },
+  "nav": { "services": "Services", "about": "About", "contact": "Contact", "cta": "Get in touch" },
+  "hero": {
+    "tag": "Independent IT Support Leader",
+    "title": "25+ Years Driving Service Excellence",
+    "lead": "Starting October 2025 I will operate as an independent professional helping organizations elevate service desk and end-user support operations.",
+    "ctaPrimary": "Get in touch",
+    "ctaSecondary": "View services",
+    "why": "What I Offer",
+    "whyPoints": [
+      "Interim IT support team leadership & supervision.",
+      "Process optimization and ITIL\u00a04–driven service improvements.",
+      "Microsoft\u00a0365 & ServiceNow implementation and management.",
+      "Mentoring and developing high-performing support teams."
+    ]
+  },
+  "services": {
+    "title": "Services",
+    "subtitle": "Support to stabilize, optimize or transform your IT operations.",
     "items": [
-      { "title": "IT TeamLead Services", "bullets": ["Tijdelijke of externe teamlead die structuur en tempo brengt.","Roadmaps, ritme (scrum) en duidelijke verantwoordelijkheden.","Focus op productiviteit én teammotivatie."] },
-      { "title": "IT Coaching", "bullets": ["1‑op‑1 begeleiding van (nieuwe) teamleads.","Communicatie, feedback en stakeholdermanagement.","Teamperformantie en groei."] },
-      { "title": "Teamopbouw & Outsourcing", "bullets": ["Advies en uitvoering bij samenstellen van teams.","Outsourcingstrategie, partnerkeuze en governance.","Kennisoverdracht en onboarding."] },
-      { "title": "Projectassistentie", "bullets": ["Implementatie en go‑live support voor nieuwe tools.","Procesverbetering en documentatie.","Tijdelijke versterking van teams."] }
-    ]},
-  "about": { "title": "Over Mezkenz", "text1": "Ik ben <b>[jouw naam]</b>, IT TeamLead met ervaring in het opbouwen en aansturen van teams. Ik combineer technische kennis met leiderschap en coaching, zodat organisaties niet alleen projecten opleveren, maar ook sterke teams bouwen die klaar zijn voor de toekomst.", "mission": "Missie: duurzame IT‑teams die efficiënt, gemotiveerd en toekomstgericht werken.", "strengthsTitle": "Troeven",
-    "strengths": ["Teams from scratch: rollen, hiring, onboarding","Heldere metrics en ritme; betere voorspelbaarheid","Coaching‑aanpak die motiveert en eigenaarschap stimuleert"] },
-  "contact": { "title": "Contact", "subtitle": "Klaar om te sparren? Stuur een bericht of plan meteen een kennismaking.",
-    "form": { "name": "Naam", "company": "Bedrijf", "email": "E‑mail", "message": "Bericht", "send": "Verstuur", "orMail": "Of mail direct" },
-    "business": { "heading": "Bedrijfsgegevens", "kbo": "KBO: [na inschrijving] · BTW: [na activatie]" } },
-  "footer": { "made": "Made with ❤️ for high‑performing teams", "rights": "Alle rechten voorbehouden" }
+      {
+        "title": "IT Team Lead Services",
+        "bullets": [
+          "Hands-on leadership for service desks and support teams.",
+          "Coaching and performance follow-up to build accountable teams.",
+          "Coordination across regions and vendors."
+        ]
+      },
+      {
+        "title": "Project Management",
+        "bullets": [
+          "Service transitions and IT migrations.",
+          "Rollout of new tools and services.",
+          "KPI tracking and reporting."
+        ]
+      },
+      {
+        "title": "Process Improvement",
+        "bullets": [
+          "ITIL\u00a04 based process optimization.",
+          "Knowledge management and documentation.",
+          "Reducing downtime and increasing user satisfaction."
+        ]
+      },
+      {
+        "title": "IT Consultancy",
+        "bullets": [
+          "Microsoft\u00a0365 & ServiceNow implementation.",
+          "Mentoring for team leads and support staff.",
+          "Strategy to build high-performing support operations."
+        ]
+      }
+    ]
+  },
+  "about": {
+    "title": "About Mezkenz",
+    "text1": "I'm <b>Mezkenz</b>, an IT support leader with more than 25 years of experience including 9 years as team lead and supervisor. I combine technical expertise with people-focused leadership to deliver stable, efficient and motivated support teams.",
+    "mission": "Mission: provide proven leadership that keeps your IT support running and evolving.",
+    "strengthsTitle": "Experience Highlights",
+    "strengths": [
+      "FedEx IT Support Supervisor 2018–2025, coordinating L2 support across Europe.",
+      "Led service transitions for multinational mergers and migrations.",
+      "ITIL\u00a04 Certified; extensive Microsoft 365 and ServiceNow expertise."
+    ]
+  },
+  "contact": {
+    "title": "Contact",
+    "subtitle": "Let's connect if you need leadership to stabilize or transform your IT support.",
+    "form": { "name": "Name", "company": "Company", "email": "Email", "message": "Message", "send": "Send", "orMail": "Or email directly" },
+    "business": { "heading": "Company details", "kbo": "KBO: [after registration] · VAT: [after activation]" }
+  },
+  "footer": { "made": "Made with ❤️ for service excellence", "rights": "All rights reserved" }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,11 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-:root{ --bg:#0b0c10; }
-
-body{ 
-  background:
-    radial-gradient(900px 500px at 15% -10%, rgba(58,163,255,.06), transparent 60%),
-    radial-gradient(1000px 600px at 85% -10%, rgba(102,209,255,.06), transparent 60%),
-    linear-gradient(to bottom, #1a1b20, #0b0c10 80%);
+body {
+  background-color: #f6f8fa;
+  color: #24292f;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
 }


### PR DESCRIPTION
## Summary
- Implement GitHub-like styling with dark header, green buttons and light components
- Refresh content with independent IT support leadership focus and detailed service offerings
- Add about, services and contact sections driven by localized dictionaries

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5e94f085c83248b5fcd6f5e09bffe