### PR TITLE
Document Resend email variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+RESEND_API_KEY=your_resend_api_key
+RESEND_FROM=verified@example.com
+RESEND_TO=recipient@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 .next/
 .vercel/
-.env*
+.env
+.env.local
+.env.*.local
+!.env.example
 dist/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ npm run dev
 
 ## Deploy
 - Vercel aanbevolen – importeer de repo, kies framework **Next.js**.
+
+## Environment variables
+- Kopieer `.env.example` naar `.env` en vul `RESEND_API_KEY`, `RESEND_FROM` en `RESEND_TO` in.
+- Verifieer het adres in `RESEND_FROM` in het Resend dashboard.
+- Redeploy je app na het aanpassen van de variabelen.


### PR DESCRIPTION
## Summary
- add example Resend environment variables
- document verifying Resend sender address and redeploying
- track `.env.example` in version control

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b60104f02483249915b1928e1d09b4